### PR TITLE
Tweaked show item toggle messaging

### DIFF
--- a/D2Stats.au3
+++ b/D2Stats.au3
@@ -91,6 +91,7 @@ func Main()
 							if ($bShowItems) then PrintString("Not showing items.", $ePrintBlue)
 							$bShowItems = False
 						else
+                            if (not $bShowItems) then PrintString("Now showing items.", $ePrintBlue)
 							$bShowItems = True
 						endif
 					endif


### PR DESCRIPTION
Added a message for when it starts showing items so that you don't have to manually verify when you are constantly toggling between them. There was already a message for when it was toggled off, but this helps improve clarity when there is not much chat to help "break up" the toggle off messages.

With this change, the last line you see will always correctly tell you whether or not items are being shown, or hidden.